### PR TITLE
Refactor MQTT client configuration and connection handling

### DIFF
--- a/lib/flutter_aws_cognito_access_iotcore_mqtt.dart
+++ b/lib/flutter_aws_cognito_access_iotcore_mqtt.dart
@@ -68,7 +68,7 @@ class FlutterAwsCognitoAccessIotcoreMqtt {
     UnsubscribeToTopicUsecase? unsubscribeToTopicUsecase,
     DisconnectUsecase? disconnectUsecase,
   }) {
-    var client =
+    MqttServerClient client =
         (mqttServerClientBuildUsecase ?? MqttServerClientBuildUsecase()).build(
       credentials: credentials,
       path: path,
@@ -176,5 +176,6 @@ class FlutterAwsCognitoAccessIotcoreMqtt {
     unSubscribeAll();
     GetIt.I.unregister<MqttClient>();
     disconnect();
+    client.disconnect();
   }
 }

--- a/lib/src/application/usecase/mqtt_server_client_build_usecase.dart
+++ b/lib/src/application/usecase/mqtt_server_client_build_usecase.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'dart:io';
 
 import 'package:aws_common/aws_common.dart';
 import 'package:aws_signature_v4/aws_signature_v4.dart';
@@ -33,6 +34,7 @@ class MqttServerClientBuildUsecase {
       log('Failed to get signed url: $e', error: e, stackTrace: s);
       throw Exception('Failed to get signed url');
     }
+
     MqttServerClient client = MqttServerClient.withPort(
       signedUrl,
       credentials.identityId,
@@ -44,9 +46,9 @@ class MqttServerClientBuildUsecase {
     client.logging(on: false);
     client.useWebSocket = true;
     client.secure = false;
-    client.autoReconnect = true;
+    client.autoReconnect = false;
     client.disconnectOnNoResponsePeriod = options.disconnectOnNoResponsePeriod;
-    client.keepAlivePeriod = options.keepAlivePeriod;
+    // client.keepAlivePeriod = options.keepAlivePeriod;
 
     final MqttConnectMessage connMess =
         MqttConnectMessage().withClientIdentifier(credentials.identityId);
@@ -108,7 +110,6 @@ class MqttServerClientBuildUsecase {
     );
     var finalParams = signed.query;
     final result = '$scheme$endpoint$urlPath?$finalParams';
-    // log('socket url: $result');
     return result;
   }
 }

--- a/lib/src/data/repositories/mqtt_client_repository_impl.dart
+++ b/lib/src/data/repositories/mqtt_client_repository_impl.dart
@@ -13,7 +13,9 @@ class MqttClientRepositoryImpl implements MqttClientRepository {
             mqttClientPayloadBuilder ?? MqttClientPayloadBuilder();
   @override
   Future<bool> connect() async {
+    
     var result = await client.connect();
+
     return result?.state == MqttConnectionState.connected;
   }
 


### PR DESCRIPTION
- Explicitly type MqttServerClient in FlutterAwsCognitoAccessIotcoreMqtt
- Modify MQTT client build process with updated connection settings
- Adjust client disconnect mechanism
- Disable auto-reconnect and remove keepAlive period configuration
- Simplify connection state checking in MqttClientRepositoryImpl